### PR TITLE
Cleanup install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,7 @@ check_write_access()
         echo "'$target' is not writable by $(whoami)"
 
         # should we be running as root?
-        if [[ `id -u` != 0 ]]; then
+        if [[ "$(id -u)" != 0 ]]; then
             echo "Run as install as root (use sudo)"
         fi
         return 1
@@ -43,20 +43,22 @@ check_write_access()
 # @TODO
 #
 # * detect a suitable prefix for Windows users
-if [ -z "$INSTALL_INTO" ] ; then
+if [ -z "$INSTALL_INTO" ]; then
     INSTALL_INTO="/usr/local/bin"
 fi
 
-REPO_DIR="$(dirname $0)"
+REPO_DIR="$(dirname "$0")"
 EXEC_FILES="git-hf"
-SCRIPT_FILES="git-hf-init git-hf-feature git-hf-hotfix git-hf-push git-hf-pull git-hf-release git-hf-support git-hf-update git-hf-upgrade git-hf-version hubflow-common hubflow-shFlags"
+SCRIPT_FILES=(git-hf-init git-hf-feature git-hf-hotfix git-hf-push
+    git-hf-pull git-hf-release git-hf-support git-hf-update git-hf-upgrade
+    git-hf-version hubflow-common hubflow-shFlags)
 SUBMODULE_FILE="hubflow-shFlags"
 
 case "$1" in
     uninstall)
         echo "Uninstalling hubflow from $INSTALL_INTO"
-        if [ -d "$INSTALL_INTO" ] ; then
-            for script_file in $SCRIPT_FILES $EXEC_FILES ; do
+        if [ -d "$INSTALL_INTO" ]; then
+            for script_file in ${SCRIPT_FILES[*]} $EXEC_FILES; do
                 echo "rm -vf $INSTALL_INTO/$script_file"
                 rm -vf "$INSTALL_INTO/$script_file"
             done
@@ -78,30 +80,32 @@ case "$1" in
 
         # if we get here, we can proceed with the install
         echo "Installing hubflow to $INSTALL_INTO"
-        if [ -f "$REPO_DIR/$SUBMODULE_FILE" ] ; then
+        if [ -f "$REPO_DIR/$SUBMODULE_FILE" ]; then
             echo "Submodules look up to date"
         else
             echo "Updating submodules"
             lastcwd="$PWD"
-            cd "$REPO_DIR"
+            cd "$REPO_DIR" || exit 1
             git submodule init -q
             git submodule update -q
-            cd "$lastcwd"
+            cd "$lastcwd" || exit 1
         fi
         install -v -d -m 0755 "$INSTALL_INTO"
-        for exec_file in $EXEC_FILES ; do
+        for exec_file in $EXEC_FILES; do
             install -v -m 0755 "$REPO_DIR/$exec_file" "$INSTALL_INTO"
         done
-        for script_file in $SCRIPT_FILES ; do
+        for script_file in ${SCRIPT_FILES[*]}; do
             install -v -m 0644 "$REPO_DIR/$script_file" "$INSTALL_INTO"
         done
 
         # also install https://github.com/github/hub
         # detect the OS and run the correct command
-        if hub --version >/dev/null 2>/dev/null ; then
-            echo "hub already installed at $(which hub)"
-	else
-            su "$SUDO_USER" -c 'brew -v >/dev/null 2>/dev/null && brew install hub' || { apt -v >/dev/null 2>/dev/null && apt install hub ; } || echo 'Could not install hub' ;
+        if hub --version >/dev/null 2>/dev/null; then
+            echo "hub already installed at $(command -v hub)"
+        else
+            su "$SUDO_USER" -c 'brew -v >/dev/null 2>/dev/null && brew install hub' \
+                || { apt -v >/dev/null 2>/dev/null && apt install hub; } \
+                || echo 'Could not install hub';
         fi
         exit
         ;;


### PR DESCRIPTION
Fixes [shellcheck](https://www.shellcheck.net/) nits. In particular, determines `hub` location with `command -v hub` rather than the non-portable `which` binary.